### PR TITLE
Fix using R8-15 in addressing

### DIFF
--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -531,7 +531,10 @@ fn encode_indirect_64(buffer: &mut InstructionBuffer, base: Option<Reg>, index: 
 
     match base {
         Some(Reg::RAX) | Some(Reg::RBX) | Some(Reg::RCX) |
-        Some(Reg::RDX) | Some(Reg::RSI) | Some(Reg::RDI) => {
+        Some(Reg::RDX) | Some(Reg::RSI) | Some(Reg::RDI) |
+        Some(Reg::R8)  | Some(Reg::R9)  | Some(Reg::R10) |
+        Some(Reg::R11) | Some(Reg::R12) | Some(Reg::R13) |
+        Some(Reg::R14) | Some(Reg::R15) => {
             match index {
                 Some(index_reg) if index_reg != Reg::RSP => {
                     buffer.mod_rm_rm = Some(4); // Force SIB


### PR DESCRIPTION
REX registers were previously not allowed in memory addressing operands (i.e., Operand::Indirect*).

To be honest, I'm not too experienced in x86 opcode encoding and I'm not to sure if this is the correct way to fix this, but it "works for me" (for now).

For example, I'm not sure if this change should be extended to `encode_indirect_32` using `Reg::R8D` etc., as it seems to be used as a fallback when `encode_indirect_64` fails.

Feel free to comment on my concerns and make suggestions for further modifications.