### PR TITLE
Convert instruction decoding panics into runtime errors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,5 +11,5 @@ license = "MIT"
 [dependencies]
 arrayvec = "0.3.23"
 byteorder = "1"
-lazy_static = "0.2"
+lazy_static = "1.4"
 matches = "0.1"

--- a/src/instruction_def.rs
+++ b/src/instruction_def.rs
@@ -53,7 +53,7 @@ pub fn load_instructions(map: &mut HashMap<Mnemonic, Vec<&'static InstructionDef
             let new_list = Vec::new();
             map.insert(instr.mnemonic, new_list);
         };
-        let mut list = map.get_mut(&instr.mnemonic).unwrap();
+        let list = map.get_mut(&instr.mnemonic).unwrap();
         list.push(&instr);
     }
 }


### PR DESCRIPTION
This PR converts various panics in `read_operand` into runtime errors that can be more gracefully handled. It also addresses a few warnings when building with Rust nightly (1.45.0).

Verified tests pass cleanly:

`test result: ok. 12717 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out`